### PR TITLE
Defer `update_cache: yes` to `apt` task

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,9 +6,9 @@
 - name: Configure the New Relic apt repository
   apt_repository:
     repo: 'deb http://apt.newrelic.com/debian/ newrelic non-free'
-    update_cache: yes
 
 - name: Install the PHP agent
   apt:
     name: newrelic-php5
     state: latest
+    update_cache: yes


### PR DESCRIPTION
Because `apt_repository` task skips `apt-get update` if repo is already added