### PR TITLE
Allow use with multiple server Trellis

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ Install [New Relic PHP agent](https://docs.newrelic.com/docs/agents/php-agent) o
 ## Role Variables
 
 ```yaml
-# group_vars/<environment>/vault.yml
+# group_vars/<environment>/vault.yml or host_vars/<host>/vault.yml
 # This file should be encrypted. See: https://roots.io/trellis/docs/vault/
 ##########################################################################
 
 # New Relic License Key
 ## See: https://docs.newrelic.com/docs/accounts-partnerships/accounts/account-setup/license-key
+# vault_newrelic_license: false
 vault_newrelic_license: xxxxxxxxxxx
 
 # group_vars/<environment>/main.yml
@@ -104,6 +105,10 @@ Add this role to `requirements.yml`:
 ```
 
 Run `$ ansible-galaxy install -r requirements.yml` to install this new role.
+
+## Multiple servers
+
+As an alternative to setting the license key for an environment under `group_vars` you can set it for a single server under `host_vars`. You can explicitly set `false` to skip a group or host, or omit the variable from the vault file. A warning will be shown when setup is skipped.
 
 ## Common Errors
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 newrelic_package_state: latest
 
+newrelic_license: "{{ vault_newrelic_license | default(false) }}"
+
 newrelic_config_default:
-  license: "{{ vault_newrelic_license }}"
+  license: "{{ newrelic_license }}"
   appname: "{{ wordpress_sites.keys() | first }} {{ env }}"
   framework: wordpress
   logfile: /var/log/newrelic/php_agent.log

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
-- name: Fail if vault_newrelic_license is not defined
-  fail:
-    msg: vault_newrelic_license is not defined
-  when: vault_newrelic_license is not defined
+- name: Warn if vault_newrelic_license is not defined
+  debug:
+      msg: |
+        Note: Skipping New Relic tasks. vault_newrelic_license is not set. Make sure this is set in vault.yml.
+  when: newrelic_license == false
 
 - include: install.yml
+  when: newrelic_license != false
 - include: ini.yml
+  when: newrelic_license != false


### PR DESCRIPTION
## Overview
Using this role as-is on a Trellis setup with multiple servers is not possible because it fails when no license key is set. This PR will only run install tasks if a license key is set, but allow provisioning to complete if it isn't.

## Use case
We're using Trellis with multiple servers, set up under `host_vars` e.g. 

```
trellis
    └── host_vars/ 
        ├── server1/ 
        └── server2/ 
            ├── wordpress_sites.yml/
            └── vault.yml/  
```

In a simplified example, we want to use New Relic on server 2 but NOT server 1. By allowing a `false` value to be set (or defaulting to it), the New Relic install tasks can be skipped for servers we don't want to install it on.

Feedback welcome and thanks for making this role available in the first place!