### PR TITLE
Readme: Use `galaxy.yml` & `trellis-cli` instead of `requirements.yml` & `ansible-galaxy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,15 @@ Add this role to `dev.yml` and `server.yml` **immediately after** `role: php`:
 
 ## Installation
 
-Add this role to `requirements.yml`:
+Add this role to `galaxy.yml`:
 
 ```yaml
 - src: TypistTech.trellis-newrelic-php # Case-sensitive!
   version: XXX.YYY.ZZZ # Check for latest version!
 ```
 
-Run `$ ansible-galaxy install -r requirements.yml` to install this new role.
+Run `$ trellis galaxy install` to install this new role.
+
 
 ## Common Errors
 


### PR DESCRIPTION
close #31 

Co-authored-by: Daniel Taki <danieltaki97@gmail.com>
Co-authored-by: Tang Rufus <tangrufus@gmail.com>