### PR TITLE
typisttech/trellis-newrelic-php:35 - Fix deprecated 'include'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,5 +4,5 @@
     msg: vault_newrelic_license is not defined
   when: vault_newrelic_license is not defined
 
-- include: install.yml
-- include: ini.yml
+- include_tasks: install.yml
+- include_tasks: ini.yml


### PR DESCRIPTION
Fixes #35 

This PR solves a deprecated error breaking Lima VM provisioning by replacing `include:` with `include_tasks`.